### PR TITLE
Add currency code to AIM transaction

### DIFF
--- a/src/net/authorize/AuthNetField.java
+++ b/src/net/authorize/AuthNetField.java
@@ -68,6 +68,7 @@ public enum AuthNetField {
 	ELEMENT_CREDIT_CARD_EXPIRY("expirationDate"),
 	ELEMENT_CREDIT_CARD_NUMBER("cardNumber"),
 	ELEMENT_CREDIT_CARD_NUMBER_MASKED("creditCardNumberMasked"),
+	ELEMENT_CURRENCY_CODE("currencyCode"),
 	ELEMENT_CUSTOMER("customer"),
 	ELEMENT_CUSTOMER_ADDRESS_ID("customerAddressId"),
 	ELEMENT_CUSTOMER_EMAIL("customerEmail"),

--- a/src/net/authorize/aim/Transaction.java
+++ b/src/net/authorize/aim/Transaction.java
@@ -35,6 +35,7 @@ public class Transaction extends net.authorize.xml.XMLTransaction implements Ser
 	private static final long serialVersionUID = 2L;
 
 	private BigDecimal totalAmount = ZERO_AMOUNT;
+	private String currencyCode = "USD";
 	protected TransactionType transactionType;
 	protected Hashtable<String, String> merchantDefinedMap = new Hashtable<String, String>();
 
@@ -114,6 +115,10 @@ public class Transaction extends net.authorize.xml.XMLTransaction implements Ser
 				this.totalAmount.setScale(Transaction.CURRENCY_DECIMAL_PLACES, BigDecimal.ROUND_HALF_UP).toPlainString()));
 		transaction_req_el.appendChild(amount_el);
 
+		// currencyCode
+		Element currency_code_el = document.createElement(AuthNetField.ELEMENT_CURRENCY_CODE.getFieldName());
+		currency_code_el.appendChild(document.getDocument().createTextNode(this.currencyCode));
+		transaction_req_el.appendChild(currency_code_el);
 
 		switch (this.transactionType) {
 		case AUTH_ONLY:
@@ -845,6 +850,20 @@ public class Transaction extends net.authorize.xml.XMLTransaction implements Ser
 			userFieldsElement.appendChild(user_field_el);
 		}
 		return userFieldsElement;
+	}
+
+	/**
+	 * @return the currency code
+	 */
+	public String getCurrencyCode() {
+		return currencyCode;
+	}
+
+	/**
+	 * @param currencyCode the currency code to set
+	 */
+	public void setCurrencyCode(String currencyCode) {
+		this.currencyCode = currencyCode;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1. Refs #8.

I added the missing `currencyCode` for AIM transactions. The API Reference is still not updated. And there's still no way to set currency for CIM transactions, but it's not even in the XML Schema, so I don't think it's possible until there's some actual work on AuthorizeNet's side.

@brianmc @ncpga @rhldr